### PR TITLE
Postgresql compatability

### DIFF
--- a/fornax/api.py
+++ b/fornax/api.py
@@ -20,6 +20,9 @@ import fornax.model as model
 # enforce foreign key constrains in SQLite
 @event.listens_for(Engine, "connect")
 def _set_sqlite_pragma(dbapi_connection, connection_record):
+    dialect_name = connection_record._ConnectionRecord__pool._dialect.name
+    if dialect_name != 'sqlite':
+        return
     cursor = dbapi_connection.cursor()
     cursor.execute("PRAGMA foreign_keys=ON")
     cursor.close()

--- a/fornax/model.py
+++ b/fornax/model.py
@@ -3,7 +3,7 @@ from sqlalchemy import PrimaryKeyConstraint, Index, UniqueConstraint
 from sqlalchemy import ForeignKey, ForeignKeyConstraint
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
-
+from sqlalchemy.types import BigInteger
 Base = declarative_base()
 
 
@@ -51,8 +51,8 @@ class Match(Base):
         )
     )
 
-    start = Column(Integer)
-    end = Column(Integer)
+    start = Column(BigInteger)
+    end = Column(BigInteger)
     start_graph_id = Column(Integer)
     end_graph_id = Column(Integer)
     query_id = Column(Integer)
@@ -96,7 +96,7 @@ class Node(Base):
         PrimaryKeyConstraint('graph_id', 'node_id'),
     )
     node_id = Column(
-        Integer,
+        BigInteger,
         CheckConstraint("node_id>=0", name="q_min_id_check")
     )
     graph_id = Column(Integer, ForeignKey("graph.graph_id"))
@@ -127,8 +127,8 @@ class Edge(Base):
         )
     )
 
-    start = Column(Integer)
-    end = Column(Integer)
+    start = Column(BigInteger)
+    end = Column(BigInteger)
     graph_id = Column(Integer)
     meta = Column(String, nullable=True)
 


### PR DESCRIPTION
In order to make Fornax compatible with postgresql:

- Use the SQLAlchemy BigInteger datatype for node IDs to explicitly use 64bit precision
- Only use the `PRAGMA foreign_keys=ON` pragma when using sqlite