### PR TITLE
set -e at the top of the multiline circle command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
             - "venv"
       - run:
           command: |
+            set -e
             . venv/bin/activate
             coverage run --source=fornax run_test.py
             coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,9 @@ jobs:
       - run:
           name: Install Python deps in a venv
           command: |
+            set -e
             python3 -m venv venv
-            . venv/bin/activate
+            source venv/bin/activate
             pip install -r requirements/dev.txt
       - save_cache:
           key: fornax-deps-{{ checksum "requirements.txt" }}
@@ -20,7 +21,7 @@ jobs:
       - run:
           command: |
             set -e
-            . venv/bin/activate
+            source venv/bin/activate
             coverage run --source=fornax run_test.py
             coveralls
       - store_test_results:


### PR DESCRIPTION
This will ensure that errors are not suppressed and are instead passed
up to fail the build.

https://support.circleci.com/hc/en-us/articles/115015733328-Tests-fail-but-job-finishes-successfully