### PR TITLE
Fix compatibility with Numpy versions 1.16 and greater  

### DIFF
--- a/fornax/opt.py
+++ b/fornax/opt.py
@@ -68,7 +68,7 @@ def group_by(columns, arr):
     split = np.split(arr, indices)
     filtered = list(filter(lambda x: len(x), split))
     keys = map(lambda x: x[columns][0].tolist(), filtered)
-    stacked = np.vstack(v for v in keys)
+    stacked = np.vstack([v for v in keys])
     return stacked, filtered
 
 


### PR DESCRIPTION
FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.